### PR TITLE
primitive type should be 1 byte instead of 4

### DIFF
--- a/pypdn/nrbf.py
+++ b/pypdn/nrbf.py
@@ -450,7 +450,7 @@ class NRBF:
 
     @_registerReader(_RecordTypeReaders, RecordType.MemberPrimitiveTyped)
     def _readMemberPrimitiveTyped(self):
-        primitiveType = self._readInt32()
+        primitiveType = self._readByte()
         value = self._PrimitiveTypeReaders[primitiveType](self)
 
         return value


### PR DESCRIPTION
See https://winprotocoldoc.blob.core.windows.net/productionwindowsarchives/MS-NRBF/%5bMS-NRBF%5d.pdf Section 2.5.1