### PR TITLE
Minimum Dependency Versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,8 @@ Introduction
 =================
 pypdn is a Python package for reading and writing Paint.NET (PDN) images.
 
+Note that python 3+ is required to use this package
+
 "Paint.NET is image and photo editing software for PCs that run Windows. It features an intuitive and innovative user interface with support for layers, unlimited undo, special effects, and a wide variety of useful and powerful tools. An active and growing online community provides friendly help, tutorials, and plugins."
 
 When using Paint.NET, the default file format that the images are saved in are PDN's, which is a proprietary format Paint.NET uses. The benefit of this format over BMP, PNG, JPEG, etc is that it stores layer information and properties that are not present in traditional image formats.

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ Introduction
 =================
 pypdn is a Python package for reading and writing Paint.NET (PDN) images.
 
-Note that python 3+ is required to use this package
+Note that python 3.4+ is required to use this package.
 
 "Paint.NET is image and photo editing software for PCs that run Windows. It features an intuitive and innovative user interface with support for layers, unlimited undo, special effects, and a wide variety of useful and powerful tools. An active and growing online community provides friendly help, tutorials, and plugins."
 

--- a/pypdn/namedlist.py
+++ b/pypdn/namedlist.py
@@ -28,8 +28,6 @@
 # Added circular dependency checks for NRBF class where it is common to have a C# .NET object contain circular
 # dependencies
 
-#pylint: disable=mixed-indentation
-
 __all__ = ['namedlist', 'namedtuple', 'NO_DEFAULT', 'FACTORY']
 
 # All of this hassle with ast is solely to provide a decent __init__
@@ -53,7 +51,6 @@ try:
     _OrderedDict = _collections.OrderedDict
 except AttributeError:
     _OrderedDict = None
-
 
 _basestring = str
 _iteritems = lambda d, **kw: iter(d.items(**kw))
@@ -174,7 +171,6 @@ def _make_fn(name, chain_fn, args, defaults):
                                                                                keywords=[]))],
                                                          decorator_list=[])],
                                  type_ignores=[])
-
     module_node = _ast.fix_missing_locations(module_node)
 
     # compile the ast

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-numpy
-scikit-image
-aenum
+numpy>=1.12
+scikit-image>=0.10
+aenum>=1.0

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(name='pypdn',
           'Source': 'https://github.com/addisonElliott/pypdn',
           'Tracker': 'https://github.com/addisonElliott/pypdn/issues',
       },
-      python_requires='>=3',
+      python_requires='>=3.4',
       packages=find_packages(),
       package_data={
         'tests': ['data/*']

--- a/setup.py
+++ b/setup.py
@@ -24,10 +24,12 @@ setup(name='pypdn',
           'License :: OSI Approved :: MIT License',
           "Programming Language :: Python",
           'Programming Language :: Python :: 3',
-          "Programming Language :: Python :: 2.7",
           "Programming Language :: Python :: 3.4",
           "Programming Language :: Python :: 3.5",
           "Programming Language :: Python :: 3.6",
+          "Programming Language :: Python :: 3.7",
+          "Programming Language :: Python :: 3.8",
+
           "Operating System :: OS Independent"
 
       ],

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ setup(name='pypdn',
           "Programming Language :: Python :: 3.6",
           "Programming Language :: Python :: 3.7",
           "Programming Language :: Python :: 3.8",
-
           "Operating System :: OS Independent"
 
       ],

--- a/setup.py
+++ b/setup.py
@@ -45,5 +45,5 @@ setup(name='pypdn',
       },
       license='MIT License',
       install_requires=[
-          'numpy', 'scikit-image', 'aenum']
+          'numpy>=1.12', 'scikit-image>=0.10', 'aenum>=1.0']
       )


### PR DESCRIPTION
Fixes #5 

- [x] - Removed python 2.7 support
- [x] - Found minimum python version required to be 3.4
- [x] - Cleanup of diffs
- [x] - Added minimum module requirements

If you need any changes made, let me know 