### PR TITLE
Fix DeprecationWarning for Python 3.9+

### DIFF
--- a/pypdn/namedlist.py
+++ b/pypdn/namedlist.py
@@ -229,7 +229,7 @@ def _fields_and_defaults(typename, field_names, default, rename):
 
     # If field_names is a Mapping, change it to return the
     #  (field_name, default) pairs, as if it were a list.
-    if isinstance(field_names, _collections.Mapping):
+    if isinstance(field_names, _collections.abc.Mapping):
         field_names = field_names.items()
 
     # Parse and validate the field names.
@@ -399,7 +399,7 @@ def _nl_index(self, value, start=NO_DEFAULT, stop=NO_DEFAULT):
 def _nl_update(_self, _other=None, **kwds):
     if isinstance(_other, type(_self)):
         _other = zip(_self._fields, _other)
-    elif isinstance(_other, _collections.Mapping):
+    elif isinstance(_other, _collections.abc.Mapping):
         tmp = []
         for field_name in _self._fields:
             try:
@@ -454,7 +454,7 @@ def namedlist(typename, field_names, default=NO_DEFAULT, rename=False,
     t = type(typename, (object,), type_dict)
 
     # Register its ABC's
-    _collections.Sequence.register(t)
+    _collections.abc.Sequence.register(t)
 
     # And return it.
     return t


### PR DESCRIPTION
Tasks
- [x] - Fix DeprecationWarning in collections so this library will support Python 3.9+

## Details 
Changed `collections.Mapping` and `collections.Sequence` to `collections.abc.Mapping` and `collections.abc.Sequence`

## Rationale
Python 3.9 is still a while off but when it hits namedlist.py will be incompatible due to collections. Given that the fix is a rather small one I thought it best to make the changes and combine the issue here

Hope this is found to be useful 😄 